### PR TITLE
Add a ``select_for_update`` option to ``djarg.qset``

### DIFF
--- a/djarg/tests/test_utils.py
+++ b/djarg/tests/test_utils.py
@@ -5,7 +5,59 @@ import ddf
 import django.contrib.auth.models as auth_models
 import pytest
 
-import djarg
+import djarg.utils
+
+
+def test_attach_select_for_update():
+    """
+    Verifies that _attached_select_for_update behaves as expected on
+    a queryset
+    """
+    qset = auth_models.User.objects.all()
+
+    # A select_for_update should never be attached to a function
+    # not running under python-args
+    new_qset = djarg.utils._attach_select_for_update(qset, None)
+    assert not new_qset.query.select_for_update
+
+    new_qset = djarg.utils._attach_select_for_update(qset, True)
+    assert not new_qset.query.select_for_update
+
+    # Test verious scenarios of properly adding a select_for_update
+    @arg.defaults(
+        qset=djarg.qset('qset', model=auth_models.User, select_for_update=True)
+    )
+    def no_args_select_for_update(qset):
+        return qset
+
+    assert no_args_select_for_update(qset).query.select_for_update
+
+    @arg.defaults(
+        qset=djarg.qset(
+            'qset', model=auth_models.User, select_for_update=['self']
+        )
+    )
+    def of_arg_select_for_update(qset):
+        return qset
+
+    assert of_arg_select_for_update(qset).query.select_for_update
+    assert of_arg_select_for_update(qset).query.select_for_update_of == [
+        'self'
+    ]
+
+    @arg.defaults(
+        qset=djarg.qset(
+            'qset',
+            model=auth_models.User,
+            select_for_update={'of': ['self'], 'skip_locked': True},
+        )
+    )
+    def kwarg_select_for_update(qset):
+        return qset
+
+    assert kwarg_select_for_update(qset).query.select_for_update
+    assert kwarg_select_for_update(qset).query.select_for_update_of == ['self']
+    assert kwarg_select_for_update(qset).query.select_for_update_skip_locked
 
 
 @pytest.mark.django_db

--- a/djarg/utils.py
+++ b/djarg/utils.py
@@ -2,6 +2,37 @@ import arg
 from django.db import models
 
 
+def _attach_select_for_update(qset, select_for_update):
+    """
+    Given a queryset, attach select_for_update parameters if we
+    are not runnnig in a partial python-args call (i.e. don't lock
+    the queryset if we are only running validators).
+
+    select_for_update can be one of:
+    1. dict: Calls select_for_update with kwargs
+    2. List[str]: Calls select_for_update with this passed to the "of"
+       argument
+    3. None: No select_for_update is ever applied.
+    4. True: select_for_update is applied with default arguments
+
+    If we are running in a partial python-args mode, no select_for_update
+    will be applied.
+    """
+    if (
+        arg.call()
+        and not arg.call().is_partial
+        and select_for_update is not None
+    ):
+        if isinstance(select_for_update, dict):
+            return qset.select_for_update(**select_for_update)
+        elif isinstance(select_for_update, (list, tuple)):
+            return qset.select_for_update(of=select_for_update)
+        else:
+            return qset.select_for_update()
+    else:
+        return qset
+
+
 class qset(arg.Lazy):
     """
     Lazily coerces a value into a queryset. Can be used inside
@@ -22,6 +53,13 @@ class qset(arg.Lazy):
             list of values is provided.
         model (Model): The model to use for the queryset when a list of
             values is provided.
+        select_for_update (List[str], default=None): Adds a select_for_update
+            using the provided arguments. Does *not* perform select_for_update
+            when running in partial mode. If a list is provided,
+            the list is used as the ``of`` argument for ``select_for_update``.
+            If a dictionary is provided, the values are passed as kwargs
+            to ``select_for_update``. If ``True`` is provided, no arguments
+            are passed to ``select_for_update``.
 
     Examples:
         Using `djarg.qset` with ``python-args`` ``arg.default`` decorator::
@@ -46,7 +84,15 @@ class qset(arg.Lazy):
             fetch_zip_codes([Profile(...), Profile(...)])
     """
 
-    def __init__(self, objects, *, qset=None, model=None, pk='pk'):
+    def __init__(
+        self,
+        objects,
+        *,
+        qset=None,
+        model=None,
+        pk='pk',
+        select_for_update=None,
+    ):
         super().__init__()
         assert isinstance(objects, str)
         if model is None and qset is None:
@@ -55,12 +101,16 @@ class qset(arg.Lazy):
         self._qset = qset if qset is not None else model._default_manager.all()
         self._objects = arg.val(objects)
         self._pk = pk
+        self._select_for_update = select_for_update
+
+    def _attach_select_for_update(self, qset):
+        return _attach_select_for_update(qset, self._select_for_update)
 
     def _call(self, **call_args):
         objects = arg.load(self._objects, **call_args)
 
         if isinstance(objects, models.QuerySet):
-            return objects
+            return self._attach_select_for_update(objects)
 
         # No object. Return empty queryset
         if objects is None:
@@ -77,8 +127,12 @@ class qset(arg.Lazy):
         # Handle list of models or list of pks
         pk_in = f'{self._pk}__in'
         if isinstance(objects[0], models.Model):
-            return self._qset.filter(
-                **{pk_in: [getattr(obj, self._pk) for obj in objects]}
+            return self._attach_select_for_update(
+                self._qset.filter(
+                    **{pk_in: [getattr(obj, self._pk) for obj in objects]}
+                )
             )
         else:
-            return self._qset.filter(**{pk_in: objects})
+            return self._attach_select_for_update(
+                self._qset.filter(**{pk_in: objects})
+            )

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -647,6 +647,27 @@ the `djarg.qset` utility.
   can also provide a ``qset`` keyword argument as a queryset to use
   when constructing the final queryset.
 
+Locking objects with ``djarg.qset``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `djarg.qset` also comes with a ``select_for_update`` parameter to
+dynamically perform locking with ``select_for_update`` if we aren't
+running in a partial python-args context (i.e. only running validators).
+
+The ``select_for_update`` argument can be supplied in three ways:
+
+1. ``djarg.qset(select_for_update=True)``: Use ``select_for_update`` with the
+   default parameters.
+2. ``djarg.qset(select_for_update=['relations']])``: Use ``select_for_update``
+   with the ``of`` argument set to the list of relations.
+3. ``djarg.qset(select_for_update={'skip_locked': True})``: Pass in keyword
+   arguments directly to ``select_for_update``.
+
+Again, the key advantage of using the ``select_for_update`` argument in
+``djarg.qset`` is that it will only apply the ``select_for_update`` when
+not running in partial ``python-args`` mode. This ensures objects won't be
+locked when only running validators, for example.
+
 Using ``djarg.views.SuccessMessageMixin``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -222,7 +222,7 @@ description = "Distribution utilities"
 name = "distlib"
 optional = false
 python-versions = "*"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 category = "dev"
@@ -380,7 +380,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
+version = "2.10"
 
 [[package]]
 category = "dev"
@@ -396,7 +396,7 @@ description = "Read metadata from Python packages"
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.1"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -573,7 +573,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.2"
+version = "1.9.0"
 
 [[package]]
 category = "dev"
@@ -681,7 +681,7 @@ description = "Python argument design patterns in a composable interface."
 name = "python-args"
 optional = false
 python-versions = ">=3.6,<4"
-version = "1.0.0"
+version = "1.0.2"
 
 [[package]]
 category = "dev"
@@ -1032,7 +1032,6 @@ version = "0.2.5"
 [[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -1043,7 +1042,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "baa37a037a6ece6717c3f310560c1e87d9a1b9dce29c45a92dfef297a112ced8"
+content-hash = "bd40b5e9225689ad135b1d5c4ec8334bb33c286ff68dff314d9db4ae9c9874bd"
 python-versions = ">=3.6,<4"
 
 [metadata.files]
@@ -1153,7 +1152,8 @@ coverage = [
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 distlib = [
-    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 dj-database-url = [
     {file = "dj-database-url-0.5.0.tar.gz", hash = "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163"},
@@ -1211,16 +1211,16 @@ identify = [
     {file = "identify-1.4.20.tar.gz", hash = "sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 imagesize = [
     {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
-    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 importlib-resources = [
     {file = "importlib_resources-2.0.1-py2.py3-none-any.whl", hash = "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6"},
@@ -1332,8 +1332,8 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:fa466306fcf6b39b8a61d003123d442b23707d635a5cb05ac4e1b62cc79105cd"},
 ]
 py = [
-    {file = "py-1.8.2-py2.py3-none-any.whl", hash = "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44"},
-    {file = "py-1.8.2.tar.gz", hash = "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"},
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
@@ -1368,8 +1368,8 @@ pytest-dotenv = [
     {file = "pytest_dotenv-0.4.0-py3-none-any.whl", hash = "sha256:12ff70de238cdc2c8d838ef92b720325ceb6ae2c9967be5f4e606a36de48345c"},
 ]
 python-args = [
-    {file = "python-args-1.0.0.tar.gz", hash = "sha256:35b57e8086d0ab879f02923fb0ab4c620af70ccc0c2470d64c32b2936897adae"},
-    {file = "python_args-1.0.0-py3-none-any.whl", hash = "sha256:6f28b8577c90e8ba26bdfa4efac48b7fed92d38d6f6043c6559ec52ae6d1fc72"},
+    {file = "python-args-1.0.2.tar.gz", hash = "sha256:414ff6f74f42fdfbc279587b8394f89331a6d9db22c890e3fb8be4dc45e8ff49"},
+    {file = "python_args-1.0.2-py3-none-any.whl", hash = "sha256:fe96c87aa9622a33d058821a9cd96fc61489bdad743cfcc0b729e1db951f9698"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ documentation = "https://django-args.readthedocs.io"
 python = ">=3.6,<4"
 django = ">=2"
 django-formtools = "^2.2"
-python-args = "^1.0.0"
+python-args = "^1.0.2"
 
 [tool.poetry.dev-dependencies]
 black = "=19.10b0"


### PR DESCRIPTION
The ``select_for_update`` option for ``djarg.qset`` can be used to dynmaically
apply ``select_for_update`` on the queryset whenever one is not running in
a partial ``python-args`` mode (such as validation-only)

Type: feature