### PR TITLE
Allow ``.qset`` utility to lazy load querysets.

### DIFF
--- a/djarg/tests/test_utils.py
+++ b/djarg/tests/test_utils.py
@@ -8,6 +8,25 @@ import pytest
 import djarg.utils
 
 
+@pytest.mark.django_db
+def test_lazy_load_qset():
+    """
+    Verifies the qset utility can be given a args.Lazy qset argument
+    """
+
+    def _get_qset(username):
+        return auth_models.User.objects.filter(username=username)
+
+    @arg.defaults(users=djarg.qset('users', qset=arg.func(_get_qset)))
+    def get_user(users):
+        return users.get()
+
+    user1 = ddf.G(auth_models.User)
+    user2 = ddf.G(auth_models.User)
+
+    assert get_user(users=[user1, user2], username=user1.username) == user1
+
+
 def test_attach_select_for_update():
     """
     Verifies that _attached_select_for_update behaves as expected on

--- a/djarg/utils.py
+++ b/djarg/utils.py
@@ -112,9 +112,14 @@ class qset(arg.Lazy):
         if isinstance(objects, models.QuerySet):
             return self._attach_select_for_update(objects)
 
+        if isinstance(self._qset, arg.Lazy):
+            qset = arg.load(self._qset, **call_args)
+        else:
+            qset = self._qset
+
         # No object. Return empty queryset
         if objects is None:
-            return self._qset.none()
+            return qset.none()
 
         # Ensure we are always working with a list from now on
         if not isinstance(objects, (list, tuple)):
@@ -122,17 +127,17 @@ class qset(arg.Lazy):
 
         # Empty list. Return empty queryset
         if not objects:
-            return self._qset.none()
+            return qset.none()
 
         # Handle list of models or list of pks
         pk_in = f'{self._pk}__in'
         if isinstance(objects[0], models.Model):
             return self._attach_select_for_update(
-                self._qset.filter(
+                qset.filter(
                     **{pk_in: [getattr(obj, self._pk) for obj in objects]}
                 )
             )
         else:
             return self._attach_select_for_update(
-                self._qset.filter(**{pk_in: objects})
+                qset.filter(**{pk_in: objects})
             )

--- a/djarg/views.py
+++ b/djarg/views.py
@@ -91,11 +91,19 @@ class SingleObjectMixin(ViewMixin, edit_views.SingleObjectMixin):
     def get_default_args(self):
         return {**super().get_default_args(), 'object': self.object}
 
+    def get_queryset(self):
+        if isinstance(self.queryset, arg.Lazy):  # pragma: no cover
+            return arg.load(self.queryset, request=self.request)
+        else:
+            return super().get_queryset()
+
     def get(self, request, *args, **kwargs):
+        self.request = request
         self.object = self.get_object()
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
+        self.request = request
         self.object = self.get_object()
         return super().post(request, *args, **kwargs)
 
@@ -164,10 +172,12 @@ class MultipleObjectsMixin(ViewMixin, edit_views.ContextMixin):
         return {**super().get_default_args(), 'objects': self.objects}
 
     def get(self, request, *args, **kwargs):
+        self.request = request
         self.objects = self.get_objects()
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
+        self.request = request
         self.objects = self.get_objects()
         return super().post(request, *args, **kwargs)
 


### PR DESCRIPTION
The ``qset`` argument for bootstrapping the ``djarg.qset`` utility can
now lazy load the querysets based on bound args.

Type: feature