### PR TITLE
Support `arg.func` wrapped queryset function in multi-object views

### DIFF
--- a/djarg/tests/urls.py
+++ b/djarg/tests/urls.py
@@ -22,9 +22,19 @@ urlpatterns = [
         name='grant_staff_access_object',
     ),
     path(
+        'grant-staff-access-if-same-name-object/<int:pk>/',
+        views.GrantStaffIfSameNameObjectView.as_view(),
+        name='grant_staff_access_if_same_name_object',
+    ),
+    path(
         'grant-staff-access-objects/',
         views.GrantStaffObjectsView.as_view(),
         name='grant_staff_access_objects',
+    ),
+    path(
+        'grant-staff-access-if-same-name-objects/',
+        views.GrantStaffIfSameNameObjectsView.as_view(),
+        name='grant_staff_access_if_same_name_objects',
     ),
     path(
         'grant-staff-access-wizard/',

--- a/djarg/tests/views.py
+++ b/djarg/tests/views.py
@@ -95,6 +95,12 @@ class GrantStaffObjectView(
     success_url = '.'
 
 
+class GrantStaffIfSameNameObjectView(GrantStaffObjectView):
+    queryset = arg.func(
+        lambda request: User.objects.filter(first_name=request.user.first_name)
+    )
+
+
 ###
 # ObjectsFormView test setup
 ###
@@ -137,6 +143,12 @@ class GrantStaffObjectsView(
 
     def get_default_args(self):
         return {**super().get_default_args(), **{'granter': self.request.user}}
+
+
+class GrantStaffIfSameNameObjectsView(GrantStaffObjectsView):
+    queryset = arg.func(
+        lambda request: User.objects.filter(first_name=request.user.first_name)
+    )
 
 
 ###

--- a/djarg/views.py
+++ b/djarg/views.py
@@ -92,7 +92,14 @@ class SingleObjectMixin(ViewMixin, edit_views.SingleObjectMixin):
         return {**super().get_default_args(), 'object': self.object}
 
     def get_queryset(self):
-        if isinstance(self.queryset, arg.Lazy):  # pragma: no cover
+        """
+        Returns the queryset for single-object views. If the queryset as been
+        overridden to be a "lazy" function (e.g. from ``python-args``), the
+        function will be evaluated with ``request`` as a keyword argument and
+        returned. Otherwise, it defaults to Django's generic detail-view
+        ``get_queryset()`` function.
+        """
+        if isinstance(self.queryset, arg.Lazy):
             return arg.load(self.queryset, request=self.request)
         else:
             return super().get_queryset()
@@ -148,11 +155,18 @@ class MultipleObjectsMixin(ViewMixin, edit_views.ContextMixin):
 
         return objects
 
-    #: Get Queryset
-    get_queryset = edit_views.SingleObjectMixin.get_queryset
-    get_queryset.__doc__ = """
-        Uses Django's SingleObjectMixin get_queryset implementation.
-    """
+    def get_queryset(self):
+        """
+        Returns the queryset for multi-object views. If the queryset as been
+        overridden to be a "lazy" function (e.g. from ``python-args``), the
+        function will be evaluated with ``request`` as a keyword argument and
+        returned. Otherwise, it defaults to Django's generic detail-view
+        ``get_queryset()`` function.
+        """
+        if isinstance(self.queryset, arg.Lazy):
+            return arg.load(self.queryset, request=self.request)
+        else:
+            return edit_views.SingleObjectMixin.get_queryset(self)
 
     def get_context_objects_name(self, objects):
         """Get the name to use for the object."""


### PR DESCRIPTION
One can declare `queryset` attribute on views with a custom function, wrapped with `arg.func` from the `python-args` library. This works fine for single-object views, as the `get_queryset()` method is overriden to support loading of those "lazy" functions.

This breaks if the view is used for multiple objects, as the queryset is handed over to Django for iteration, but it is not iterable, but a `arg.func` object.

I found this bug when implementing a multi-object view in a different codebase, and after looking into it, this seemed to be fairly straight forward to fix. But I definitely want your thoughts and review on this @wesleykendall, in case there was a good reason this wasn't supported before.

I can also file this as an issue, if you would prefer to have it documented there, Wes, and I'll also gladly accept any amendments to my suggested fix here.

I removed one "# pragma: no-cover" comment, and added unit-tests for both single-object view (which passed) and multi-object view (which broke) before implementing the fix.

Type: bug